### PR TITLE
Wrong filename for dev output(s)

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -19,7 +19,7 @@ const cfg = merge(webpackConfig, {
     dev: path.resolve(__dirname, './empty.js'),
   },
   output: {
-    filename: 'index.[name].user.js',
+    filename: 'output.filename.[name].user.js',
     path: path.resolve(__dirname, '../dist'),
   },
   devtool: 'inline-source-map',


### PR DESCRIPTION
This causes `@require` to not match the actual filename(s).

![image](https://user-images.githubusercontent.com/4130991/82591654-4c295200-9b65-11ea-89f6-c65326190668.png)
