### PR TITLE
fix: webpack config typo

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -45,7 +45,7 @@ const webpackConfig = {
       },
       {
         test: /\.css$/,
-        loaders: [
+        loader: [
           'style-loader',
           'css-loader',
         ]


### PR DESCRIPTION
webpack的config中写错了一个配置项键

